### PR TITLE
chore: bump jina version to 2.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:2.0.7
+FROM jinaai/jina:2.0.7-py37-perf
 
 COPY . ./image_normalizer/
 WORKDIR ./image_normalizer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:2.0
+FROM jinaai/jina:2.0.7
 
 COPY . ./image_normalizer/
 WORKDIR ./image_normalizer


### PR DESCRIPTION
This PR bumps Jina version to 2.0.7.